### PR TITLE
Optimized image files v2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseurl = "https://www.onlyspoolz.com/"
 title = "Database of filament spools info"
 theme = "hugo-creative-portfolio-theme"
 languageCode = "en-us"
+assetDir = "static"
 # Enable comments by entering your Disqus shortname
 disqusShortname = ""
 # Enable Google Analytics by entering your tracking code

--- a/themes/hugo-creative-portfolio-theme/layouts/partials/portfolio.html
+++ b/themes/hugo-creative-portfolio-theme/layouts/partials/portfolio.html
@@ -6,12 +6,15 @@
               <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 masonry-item">
                   <div class="box-masonry">
                       {{ if and (isset .Params "image") .Params.image }}
+                        {{ $img := resources.Get .Params.image }}
+                        {{ $optimized := $img.Fit "1100x1100 webp picture q60" }}
                         {{ if eq .Params.showonlyimage true }}
                         <a href="{{ .Permalink }}" title="" class="box-masonry-image with-hover-overlay">
                         {{ else }}
                         <a href="{{ .Permalink }}" title="" class="box-masonry-image with-hover-overlay with-hover-icon">
                         {{ end }}
-                            <img src="{{.Params.image | absURL}}" alt="" class="img-responsive">
+                            <img src="{{ $optimized.RelPermalink }}" width="{{ $optimized.Width }}" height="{{ $optimized.Height }}"
+                              loading="lazy" alt="" class="img-responsive">
                         </a>
                       {{ end }}
                       {{ if eq .Params.showonlyimage true }}


### PR DESCRIPTION
This is a follow-up and improvement to my PR yesterday in #37. See that for context.
Instead of manually needing image conversion, with loads of extra images in the repo, this auto-generates optimized webp images via Hugo.

This does mean that initial hugo builds can take a while extra, but rendered images are cached by Hugo so that typically only takes time during the first run, unless extra images have been added since.

This also sets image dimensions (auto-extracted from the hugo build process) on the images on the portfolio templates, so their dimension/aspect ratio are known to the browser, allowing browser-native lazy loading to be applied without messing up the masonry layout.

Reduces main page load from 103MB to 5.28MB, potentially less if the browser uses lazy loading.